### PR TITLE
Tambah Laporan Arus Kas: generate dari tabel_transaksi + mapping COA

### DIFF
--- a/app/Http/Controllers/JurnalKeluarController.php
+++ b/app/Http/Controllers/JurnalKeluarController.php
@@ -59,7 +59,6 @@ class JurnalKeluarController extends Controller
                     'tanggal_posting' => $item['tanggal_transaksi'],
                     'keterangan_posting' => 'Post',
                     'id_admin' => Auth::user()->id,
-                    'arus_kas' => Auth::user()->unit,
                     'created_at' => now(),
                     'updated_at' => now()
                 ]);
@@ -77,7 +76,6 @@ class JurnalKeluarController extends Controller
                         'tanggal_posting' => $item['tanggal_transaksi'],
                         'keterangan_posting' => 'Post',
                         'id_admin' => Auth::user()->id,
-                        'arus_kas' => Auth::user()->unit,
                         'created_at' => now(),
                         'updated_at' => now()
                     ]);

--- a/app/Http/Controllers/JurnalMasukController.php
+++ b/app/Http/Controllers/JurnalMasukController.php
@@ -64,7 +64,6 @@ class JurnalMasukController extends Controller
                     'tanggal_posting' => $item['tanggal_transaksi'],
                     'keterangan_posting' => 'Post',
                     'id_admin' => Auth::user()->id,
-                    'arus_kas' => Auth::user()->unit,
                     'created_at' => now(),
                     'updated_at' => now()
                 ]);
@@ -81,7 +80,6 @@ class JurnalMasukController extends Controller
                     'tanggal_posting' => $item['tanggal_transaksi'],
                     'keterangan_posting' => 'Post',
                     'id_admin' => Auth::user()->id,
-                    'arus_kas' => Auth::user()->unit,
                     'created_at' => now(),
                     'updated_at' => now()
                 ]);

--- a/app/Http/Controllers/JurnalUmumController.php
+++ b/app/Http/Controllers/JurnalUmumController.php
@@ -62,7 +62,6 @@ class JurnalUmumController extends Controller
                     'tanggal_posting' => $item['tanggal_transaksi'],
                     'keterangan_posting' => 'Post',
                     'id_admin' => Auth::user()->id,
-                    'arus_kas' => Auth::user()->unit,
                     'created_at' => now(),
                     'updated_at' => now()
                 ]);

--- a/app/Http/Controllers/ReportArusKasController.php
+++ b/app/Http/Controllers/ReportArusKasController.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Menu;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class ReportArusKasController extends Controller
+{
+    private function getKategori(): array
+    {
+        return DB::table('arus_kas_kategori')
+            ->orderBy('urutan')
+            ->get()
+            ->mapWithKeys(fn ($row) => [$row->code_arus_kas => [
+                'line' => $row->line,
+                'nama' => $row->nama,
+                'group_heading' => $row->group_heading,
+            ]])
+            ->all();
+    }
+
+    private const EXCLUDED_GR_HEAD = ['1100000', '1300000'];
+    private const EXCLUDED_KODE = [
+        '1481000', '1421000', '1423000', '1512000', '1913000', '1962000', '1963000', '2472000', '9141000', '9910000',
+        '1621000', '1672000', '52911', '52915', '1949000',
+    ];
+
+    public function index()
+    {
+        $title = 'Laporan Arus Kas';
+        $menus = Menu::whereNull('parent_id')->with('children')->orderBy('order')->get();
+        $unit = Auth::user()->unit;
+
+        $rows = DB::table('tabel_master_kas')
+            ->where('unit', $unit)
+            ->orderBy('gl_arus_kas')
+            ->get()
+            ->keyBy('code_arus_kas');
+
+        $periode = $rows->first();
+
+        return view('admin.report_arus_kas.index', [
+            'title' => $title,
+            'menus' => $menus,
+            'kategori' => $this->getKategori(),
+            'rows' => $rows,
+            'periodeAwal' => $periode->periode_awal ?? null,
+            'periodeAkhir' => $periode->periode_akhir ?? null,
+            'rekonsiliasi' => null,
+        ]);
+    }
+
+    public function generate(Request $request)
+    {
+        $request->validate([
+            'tanggal_awal' => 'required|date',
+            'tanggal_akhir' => 'required|date|after_or_equal:tanggal_awal',
+        ]);
+
+        $unit = Auth::user()->unit;
+        $tanggalAwal = $request->tanggal_awal;
+        $tanggalAkhir = $request->tanggal_akhir;
+
+        $aggregat = DB::table('tabel_transaksi')
+            ->where('unit', $unit)
+            ->whereBetween('tanggal_transaksi', ["{$tanggalAwal} 00:00:00", "{$tanggalAkhir} 23:59:59"])
+            ->select('kode_rekening', DB::raw('SUM(debet) as tot_debet'), DB::raw('SUM(kredit) as tot_kredit'))
+            ->groupBy('kode_rekening')
+            ->get();
+
+        $mappings = DB::table('coa_arus_kas_mappings')->get();
+        $kodeRules = $mappings->where('match_type', 'kode_rekening')->groupBy('match_value');
+        $prefixRules = $mappings->where('match_type', 'prefix');
+        $grHeadRules = $mappings->where('match_type', 'gr_head')->groupBy('match_value');
+        $coaGrHead = DB::table('coa')->whereNotNull('gr_head')->where('gr_head', '!=', '')->pluck('gr_head', 'kode_rek');
+
+        $kategoriTotals = [];
+        $unclassifiedDebet = 0;
+        $unclassifiedKredit = 0;
+        $kasDebet = 0;
+        $kasKredit = 0;
+
+        foreach ($aggregat as $row) {
+            $kode = $row->kode_rekening;
+            $grHead = $coaGrHead[$kode] ?? null;
+
+            if (in_array($grHead, self::EXCLUDED_GR_HEAD, true)) {
+                $kasDebet += $row->tot_debet;
+                $kasKredit += $row->tot_kredit;
+                continue;
+            }
+
+            if (in_array($kode, self::EXCLUDED_KODE, true)) {
+                continue;
+            }
+
+            $rules = $kodeRules->get($kode);
+
+            if (!$rules) {
+                foreach ($prefixRules as $prefixRule) {
+                    if (str_starts_with($kode, $prefixRule->match_value)) {
+                        $rules = collect([$prefixRule]);
+                        break;
+                    }
+                }
+            }
+
+            if (!$rules && $grHead && $grHeadRules->has($grHead)) {
+                $rules = $grHeadRules->get($grHead);
+            }
+
+            if (!$rules) {
+                $unclassifiedDebet += $row->tot_debet;
+                $unclassifiedKredit += $row->tot_kredit;
+                continue;
+            }
+
+            foreach ($rules as $rule) {
+                $code = $rule->code_arus_kas;
+                $kategoriTotals[$code] ??= ['debet' => 0, 'kredit' => 0];
+
+                if ($rule->arah === 'debet' || $rule->arah === 'both') {
+                    $kategoriTotals[$code]['debet'] += $row->tot_debet;
+                }
+                if ($rule->arah === 'kredit' || $rule->arah === 'both') {
+                    $kategoriTotals[$code]['kredit'] += $row->tot_kredit;
+                }
+            }
+        }
+
+        $kategori = $this->getKategori();
+        $totalNettoKategori = 0;
+
+        foreach ($kategori as $code => $meta) {
+            if ($meta['line'] !== 'DETAIL') {
+                continue;
+            }
+
+            $mutDebet = $kategoriTotals[$code]['debet'] ?? 0;
+            $mutKredit = $kategoriTotals[$code]['kredit'] ?? 0;
+            $totalNettoKategori += $mutKredit - $mutDebet;
+
+            $existing = DB::table('tabel_master_kas')->where('unit', $unit)->where('code_arus_kas', $code)->first();
+            $saldoAwal = $existing->saldo_akhir ?? 0;
+            $saldoAkhir = $saldoAwal + ($mutKredit - $mutDebet);
+
+            DB::table('tabel_master_kas')->updateOrInsert(
+                ['unit' => $unit, 'code_arus_kas' => $code],
+                [
+                    'gl_arus_kas' => $unit . '-' . $code,
+                    'line' => $meta['line'],
+                    'nama_arus_kas' => $meta['nama'],
+                    'group_heading' => $meta['group_heading'],
+                    'mut_debet' => $mutDebet,
+                    'mut_kredit' => $mutKredit,
+                    'saldo_awal' => $saldoAwal,
+                    'saldo_akhir' => $saldoAkhir,
+                    'saldo_tahun' => $saldoAkhir,
+                    'periode_awal' => $tanggalAwal,
+                    'periode_akhir' => $tanggalAkhir,
+                    'updated_at' => now(),
+                    'created_at' => now(),
+                ]
+            );
+        }
+
+        $perubahanKasRiil = $kasDebet - $kasKredit;
+        $selisihRekonsiliasi = $totalNettoKategori - $perubahanKasRiil;
+
+        $rows = DB::table('tabel_master_kas')
+            ->where('unit', $unit)
+            ->orderBy('gl_arus_kas')
+            ->get()
+            ->keyBy('code_arus_kas');
+
+        $title = 'Laporan Arus Kas';
+        $menus = Menu::whereNull('parent_id')->with('children')->orderBy('order')->get();
+
+        return view('admin.report_arus_kas.index', [
+            'title' => $title,
+            'menus' => $menus,
+            'kategori' => $kategori,
+            'rows' => $rows,
+            'periodeAwal' => $tanggalAwal,
+            'periodeAkhir' => $tanggalAkhir,
+            'rekonsiliasi' => [
+                'total_netto_kategori' => $totalNettoKategori,
+                'perubahan_kas_riil' => $perubahanKasRiil,
+                'selisih' => $selisihRekonsiliasi,
+                'unclassified_debet' => $unclassifiedDebet,
+                'unclassified_kredit' => $unclassifiedKredit,
+            ],
+        ]);
+    }
+}

--- a/app/Models/CoaArusKasMapping.php
+++ b/app/Models/CoaArusKasMapping.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CoaArusKasMapping extends Model
+{
+    protected $table = 'coa_arus_kas_mappings';
+
+    protected $fillable = [
+        'match_type',
+        'match_value',
+        'arah',
+        'code_arus_kas',
+        'keterangan',
+    ];
+}

--- a/database/migrations/2026_07_08_025529_fix_tabel_master_kas_unique_constraint.php
+++ b/database/migrations/2026_07_08_025529_fix_tabel_master_kas_unique_constraint.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tabel_master_kas', function (Blueprint $table) {
+            $table->dropUnique('tabel_master_kas_code_arus_kas_unique');
+            $table->unique(['unit', 'code_arus_kas']);
+            $table->date('periode_awal')->nullable()->after('saldo_tahun');
+            $table->date('periode_akhir')->nullable()->after('periode_awal');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tabel_master_kas', function (Blueprint $table) {
+            $table->dropColumn(['periode_awal', 'periode_akhir']);
+            $table->dropUnique(['unit', 'code_arus_kas']);
+            $table->unique('code_arus_kas');
+        });
+    }
+};

--- a/database/migrations/2026_07_08_025530_add_unit_tanggal_index_to_tabel_transaksi.php
+++ b/database/migrations/2026_07_08_025530_add_unit_tanggal_index_to_tabel_transaksi.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tabel_transaksi', function (Blueprint $table) {
+            $table->index(['unit', 'tanggal_transaksi'], 'idx_unit_tanggal');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tabel_transaksi', function (Blueprint $table) {
+            $table->dropIndex('idx_unit_tanggal');
+        });
+    }
+};

--- a/database/migrations/2026_07_08_025530_create_coa_arus_kas_mappings_table.php
+++ b/database/migrations/2026_07_08_025530_create_coa_arus_kas_mappings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('coa_arus_kas_mappings', function (Blueprint $table) {
+            $table->id();
+            $table->enum('match_type', ['kode_rekening', 'gr_head', 'prefix']);
+            $table->string('match_value', 25);
+            $table->enum('arah', ['debet', 'kredit', 'both']);
+            $table->string('code_arus_kas', 8);
+            $table->string('keterangan')->nullable();
+            $table->timestamps();
+
+            $table->unique(['match_type', 'match_value', 'arah'], 'uniq_mapping_rule');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('coa_arus_kas_mappings');
+    }
+};

--- a/database/migrations/2026_07_08_033138_create_arus_kas_kategori_table.php
+++ b/database/migrations/2026_07_08_033138_create_arus_kas_kategori_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('arus_kas_kategori', function (Blueprint $table) {
+            $table->string('code_arus_kas', 8)->primary();
+            $table->enum('line', ['HEADING', 'SUB HEADING', 'DETAIL']);
+            $table->string('nama', 150);
+            $table->string('group_heading', 8);
+            $table->unsignedInteger('urutan');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('arus_kas_kategori');
+    }
+};

--- a/database/seeders/ArusKasKategoriSeeder.php
+++ b/database/seeders/ArusKasKategoriSeeder.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ArusKasKategoriSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $rows = [
+            ['11000', 'HEADING', 'KEGIATAN OPERASI', '11000', 10],
+            ['11200', 'DETAIL', 'Penerimaan simpanan dari anggota dan koperasi lain', '11000', 20],
+            ['11300', 'DETAIL', 'Penyaluran pembiayaan kepada anggota dan koperasi lain', '11000', 30],
+            ['11400', 'DETAIL', 'Penerimaan dari pembiayaan kepada anggota dan koperasi lain', '11000', 40],
+            ['11500', 'DETAIL', 'Penerimaan pendapatan dari pembiayaan kepada anggota dan koperasi lain', '11000', 50],
+            ['11600', 'DETAIL', 'Pembayaran bagi hasil kepada anggota dan koperasi lain', '11000', 60],
+            ['11700', 'DETAIL', 'Penerimaan pembiayaan dari pihak lain', '11000', 70],
+            ['11800', 'DETAIL', 'Pembayaran pembiayaan dari pihak lain', '11000', 80],
+            ['11900', 'DETAIL', 'Pembayaran bagi hasil kepada pihak lain', '11000', 90],
+            ['11910', 'DETAIL', 'Biaya imbalan kerja', '11000', 100],
+            ['11920', 'DETAIL', 'Biaya operasional', '11000', 110],
+            ['12000', 'HEADING', 'KEGIATAN INVESTASI', '12000', 120],
+            ['12200', 'DETAIL', 'Penempatan Deposito Jangka Panjang', '12000', 130],
+            ['12300', 'DETAIL', 'Penerimaan Bunga Deposito', '12000', 140],
+            ['12400', 'DETAIL', 'Pencairan Deposito', '12000', 150],
+            ['12500', 'DETAIL', 'Perolehan aset tetap', '12000', 160],
+            ['12600', 'DETAIL', 'Pelepasan aset tetap', '12000', 170],
+            ['12700', 'DETAIL', 'Perolehan aset tak berwujud', '12000', 180],
+            ['12800', 'DETAIL', 'Pelepasan aset tak berwujud', '12000', 190],
+            ['13000', 'HEADING', 'KEGIATAAN PENDANAAN', '13000', 200],
+            ['13200', 'SUB HEADING', 'Penambahan modal :', '13000', 210],
+            ['13300', 'DETAIL', 'Simpanan pokok/modal tetap', '13000', 220],
+            ['13400', 'DETAIL', 'Simpanan wajib/modal tambahan', '13000', 230],
+            ['13500', 'DETAIL', 'Penempatan Dana Investasi', '13000', 240],
+            ['13600', 'DETAIL', 'Penerimaan pinjaman bank/lembaga keuangan lain', '13000', 250],
+            ['13700', 'SUB HEADING', 'Pengurangan modal :', '13000', 260],
+            ['13800', 'DETAIL', 'Simpanan pokok/modal tetap', '13000', 270],
+            ['13900', 'DETAIL', 'Simpanan wajib/modal tambahan', '13000', 280],
+            ['13910', 'DETAIL', 'Pencairan Dana Investasi', '13000', 290],
+            ['13920', 'DETAIL', 'Pembayaran pinjaman bank / lembaga keuangan lain', '13000', 300],
+            ['13930', 'DETAIL', 'Pembayaran Bagi Hasil anggota Dana Investasi', '13000', 310],
+            ['13940', 'DETAIL', 'Penerimaan dana antar kantor (RAK)', '13000', 320],
+            ['13950', 'DETAIL', 'Pengiriman dana antar kantor (RAK)', '13000', 330],
+        ];
+
+        foreach ($rows as [$code, $line, $nama, $groupHeading, $urutan]) {
+            DB::table('arus_kas_kategori')->updateOrInsert(
+                ['code_arus_kas' => $code],
+                [
+                    'line' => $line,
+                    'nama' => $nama,
+                    'group_heading' => $groupHeading,
+                    'urutan' => $urutan,
+                    'updated_at' => now(),
+                    'created_at' => now(),
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/CoaArusKasMappingSeeder.php
+++ b/database/seeders/CoaArusKasMappingSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CoaArusKasMappingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $rows = [
+            ['kode_rekening', '1413000', 'debet', '11300', 'Piutang Murabahah Mingguan - penyaluran'],
+            ['kode_rekening', '1413000', 'kredit', '11400', 'Piutang Murabahah Mingguan - penerimaan pokok'],
+            ['kode_rekening', '1411000', 'debet', '11300', 'Piutang Murabahah Restrukturisasi - penyaluran'],
+            ['kode_rekening', '1411000', 'kredit', '11400', 'Piutang Murabahah Restrukturisasi - penerimaan pokok'],
+            ['kode_rekening', '1431000', 'debet', '11300', 'Piutang Wakalah - penyaluran'],
+            ['kode_rekening', '1431000', 'kredit', '11400', 'Piutang Wakalah - penerimaan pokok'],
+            ['kode_rekening', '1472000', 'debet', '11300', 'Pembiayaan Musyarakah - penyaluran'],
+            ['kode_rekening', '1472000', 'kredit', '11400', 'Pembiayaan Musyarakah - penerimaan pokok'],
+            ['kode_rekening', '41002', 'kredit', '11500', 'PM-Murabahah-Kelompok Mingguan'],
+            ['kode_rekening', '42356', 'kredit', '11500', 'POL-Penerimaan Kembali HB'],
+            ['kode_rekening', '2101000', 'both', '11200', 'Simpanan Wadiah Kelompok'],
+            ['kode_rekening', '3102000', 'kredit', '13300', 'SP-Anggota - penambahan'],
+            ['kode_rekening', '3102000', 'debet', '13800', 'SP-Anggota - pengurangan'],
+            ['kode_rekening', '3202000', 'kredit', '13400', 'SW-Anggota - penambahan'],
+            ['kode_rekening', '3202000', 'debet', '13900', 'SW-Anggota - pengurangan'],
+            ['kode_rekening', '1600000', 'debet', '12500', 'Aktiva Tetap Tanah/Gedung - perolehan'],
+            ['kode_rekening', '1600000', 'kredit', '12600', 'Aktiva Tetap Tanah/Gedung - pelepasan'],
+            ['kode_rekening', '1650000', 'debet', '12500', 'Aktiva Tetap Inventaris - perolehan'],
+            ['kode_rekening', '1650000', 'kredit', '12600', 'Aktiva Tetap Inventaris - pelepasan'],
+            ['prefix', '1010-', 'kredit', '13940', 'RAK - penerimaan dana antar kantor'],
+            ['prefix', '1010-', 'debet', '13950', 'RAK - pengiriman dana antar kantor'],
+            ['kode_rekening', '2500000', 'kredit', '13940', 'RAK PASIVA - KP - penerimaan dana antar kantor'],
+            ['kode_rekening', '2500000', 'debet', '13950', 'RAK PASIVA - KP - pengiriman dana antar kantor'],
+            ['kode_rekening', '41004', 'debet', '11600', 'BH-Mudharabah - pembayaran bagi hasil anggota'],
+            ['kode_rekening', '1953000', 'both', '11920', 'Persediaan-Materai'],
+            ['kode_rekening', '57202', 'kredit', '13940', 'PNO-Bg Hsl/Bns/Margin Antar Kantor-RAK AP'],
+            ['gr_head', '40000', 'kredit', '11500', 'Pendapatan Operasional (fallback)'],
+            ['gr_head', '50000', 'debet', '11920', 'Biaya Operasional (fallback)'],
+            ['gr_head', '57000', 'kredit', '12300', 'Pendapatan Non Operasional (fallback)'],
+            ['gr_head', '58000', 'debet', '11920', 'Beban Non Operasional (fallback)'],
+        ];
+
+        foreach ($rows as [$matchType, $matchValue, $arah, $codeArusKas, $keterangan]) {
+            DB::table('coa_arus_kas_mappings')->updateOrInsert(
+                ['match_type' => $matchType, 'match_value' => $matchValue, 'arah' => $arah],
+                ['code_arus_kas' => $codeArusKas, 'keterangan' => $keterangan, 'updated_at' => now(), 'created_at' => now()]
+            );
+        }
+    }
+}

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -509,6 +509,16 @@ class MenuSeeder extends Seeder
             'role_id' => 1,
         ]);
 
+        Menu::create([
+            'name' => 'Arus Kas',
+            'icon' => 'far fa-circle nav-icon',
+            'parent_id' => $report->id,
+            'url' => '/report/arus-kas',
+            'left' => 'null',
+            'order' => 44,
+            'role_id' => 1,
+        ]);
+
 
         $mobcoll = Menu::create([
             'name' => 'Mobcoll',

--- a/resources/views/admin/report_arus_kas/index.blade.php
+++ b/resources/views/admin/report_arus_kas/index.blade.php
@@ -1,0 +1,117 @@
+@extends('layouts.main')
+
+@section('content-header')
+    <div class="container-fluid">
+        <div class="row mb-2">
+            <div class="col-sm-6">
+                <h1>Laporan Arus Kas</h1>
+            </div>
+            <div class="col-sm-6">
+                <ol class="breadcrumb float-sm-right">
+                    <li class="breadcrumb-item"><a href="#">Home</a></li>
+                    <li class="breadcrumb-item active">Laporan Arus Kas</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@section('content')
+    <div class="card mb-4">
+        <div class="card-body">
+            <form id="formArusKas" action="{{ route('report.arus-kas.generate') }}" method="POST">
+                @csrf
+
+                <div class="form-group row">
+                    <label class="col-sm-3 col-form-label">Tanggal Awal</label>
+                    <div class="col-sm-4">
+                        <input type="date" name="tanggal_awal" class="form-control" value="{{ $periodeAwal }}" required>
+                    </div>
+                    <label class="col-sm-1 col-form-label text-center">s/d</label>
+                    <div class="col-sm-4">
+                        <input type="date" name="tanggal_akhir" class="form-control" value="{{ $periodeAkhir }}" required>
+                    </div>
+                </div>
+
+                <div class="text-center">
+                    <button type="submit" class="btn btn-primary">Generate</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if($rekonsiliasi)
+        <div class="alert {{ abs($rekonsiliasi['selisih']) < 1 ? 'alert-success' : 'alert-warning' }}">
+            <strong>Rekonsiliasi Kas:</strong>
+            Total netto arus kas Rp {{ number_format($rekonsiliasi['total_netto_kategori'], 0, ',', '.') }},
+            perubahan saldo riil akun Kas &amp; Bank Rp {{ number_format($rekonsiliasi['perubahan_kas_riil'], 0, ',', '.') }},
+            selisih Rp {{ number_format($rekonsiliasi['selisih'], 0, ',', '.') }}.
+            @if(abs($rekonsiliasi['selisih']) >= 1)
+                Ada selisih - periksa kembali mapping COA di <code>coa_arus_kas_mappings</code>.
+            @endif
+            @if($rekonsiliasi['unclassified_debet'] > 0 || $rekonsiliasi['unclassified_kredit'] > 0)
+                <br><strong>Belum Terklasifikasi:</strong>
+                debet Rp {{ number_format($rekonsiliasi['unclassified_debet'], 0, ',', '.') }},
+                kredit Rp {{ number_format($rekonsiliasi['unclassified_kredit'], 0, ',', '.') }}
+                - ada kode rekening yang belum ada di tabel mapping.
+            @endif
+        </div>
+    @endif
+
+    @if($rows->isNotEmpty())
+        <div class="card">
+            <div class="card-body">
+                <table class="table table-bordered table-sm">
+                    <thead>
+                        <tr>
+                            <th>Uraian</th>
+                            <th class="text-end">Mutasi Debet</th>
+                            <th class="text-end">Mutasi Kredit</th>
+                            <th class="text-end">Saldo Awal</th>
+                            <th class="text-end">Saldo Akhir</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($kategori as $code => $meta)
+                            @php $row = $rows->get($code); @endphp
+                            <tr class="{{ $meta['line'] === 'HEADING' ? 'table-secondary' : '' }}">
+                                <td class="{{ $meta['line'] === 'DETAIL' ? 'ps-4' : '' }}">
+                                    <strong>{{ $meta['nama'] }}</strong>
+                                </td>
+                                @if($meta['line'] === 'DETAIL')
+                                    <td class="text-end">{{ number_format($row->mut_debet ?? 0, 0, ',', '.') }}</td>
+                                    <td class="text-end">{{ number_format($row->mut_kredit ?? 0, 0, ',', '.') }}</td>
+                                    <td class="text-end">{{ number_format($row->saldo_awal ?? 0, 0, ',', '.') }}</td>
+                                    <td class="text-end">{{ number_format($row->saldo_akhir ?? 0, 0, ',', '.') }}</td>
+                                @else
+                                    <td colspan="4"></td>
+                                @endif
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    @endif
+@endsection
+
+@push('scripts')
+    <script>
+        document.getElementById('formArusKas').addEventListener('submit', function (e) {
+            e.preventDefault();
+
+            Swal.fire({
+                title: 'Memproses Data...',
+                text: 'Mohon tunggu, generate arus kas bisa memakan waktu beberapa saat',
+                allowOutsideClick: false,
+                didOpen: () => {
+                    Swal.showLoading()
+                }
+            });
+
+            setTimeout(() => {
+                this.submit();
+            }, 500);
+        });
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,7 @@ use App\Http\Controllers\PelunasanKelompokController;
 use App\Http\Controllers\PelunasanController;
 use App\Http\Controllers\PemindahbukuanPerkelompokController;
 use App\Http\Controllers\ReportEkuitasController;
+use App\Http\Controllers\ReportArusKasController;
 use App\Http\Controllers\ReportNominativeSimpananController;
 use App\Http\Controllers\ReportNominativePembiayaanController;
 use App\Http\Controllers\RestrukturisasiJatuhTempoController;
@@ -279,6 +280,10 @@ Route::group(['middleware' => ['auth', 'role:1']], function () {
     Route::get('/report/nominative-simpanan', [ReportNominativeSimpananController::class, 'index']);
     Route::post('/report/nominative-simpanan/get-data', [ReportNominativeSimpananController::class, 'getData'])->name('nominativeSimpanan.getData');
     Route::get('/report/nominative-simpanan/export', [ReportNominativeSimpananController::class, 'export'])->name('nominativeSimpanan.export');
+
+
+    Route::get('/report/arus-kas', [ReportArusKasController::class, 'index'])->name('report.arus-kas.index');
+    Route::post('/report/arus-kas/generate', [ReportArusKasController::class, 'generate'])->name('report.arus-kas.generate');
 
 
     Route::get('/pull-data', [PullDataController::class, 'index']);


### PR DESCRIPTION
- Controller ReportArusKasController: agregasi tabel_transaksi per unit+periode, klasifikasi via tabel coa_arus_kas_mappings, simpan snapshot ke tabel_master_kas
- Tabel baru: coa_arus_kas_mappings (mapping COA->kategori), arus_kas_kategori (katalog kategori operasi/investasi/pendanaan, bisa diubah tanpa deploy)
- Index (unit, tanggal_transaksi) di tabel_transaksi untuk performa generate
- Fix unique constraint tabel_master_kas jadi per-unit (sebelumnya global, bentrok kalau lebih dari satu unit)
- Fix bug kolom 'arus_kas' yang tidak ada skemanya di JurnalUmum/Keluar/MasukController
- Menu & route baru: /report/arus-kas